### PR TITLE
refactor(jobs): enhance date range calculation for streak management;…

### DIFF
--- a/apps/backend/src/controllers/jobs/userActivity.controller.ts
+++ b/apps/backend/src/controllers/jobs/userActivity.controller.ts
@@ -116,7 +116,10 @@ export class UserActivityController {
 
   public resetStreak = async (req: Request, res: Response) => {
     try {
-      const { from, to } = getDayWindow();
+      const { from, to } =
+        req.body?.from && req.body?.to
+          ? { from: new Date(req.body.from), to: new Date(req.body.to) }
+          : getDayWindow();
 
       if (from >= to) {
         console.error("Invalid date range: from >= to");

--- a/apps/backend/src/jobs/tasks/streak.job.ts
+++ b/apps/backend/src/jobs/tasks/streak.job.ts
@@ -1,18 +1,44 @@
 import { UserActivityController } from "@/controllers/jobs/userActivity.controller";
 import { Logger } from "@/lib/logger";
+import { addDays, setHours, setMinutes, setSeconds } from "date-fns";
 
 export const streakJob = async () => {
   const logger = new Logger("Streak");
   try {
     logger.info("Running Reset Streak Job");
 
+    const IST_OFFSET_MS: number = 5.5 * 60 * 60 * 1000;
+    const now: Date = new Date();
+    const istNow: Date = new Date(now.getTime() + IST_OFFSET_MS);
+
+    let ist1150PM: Date = setSeconds(setMinutes(setHours(istNow, 23), 50), 0);
+
+    if (
+      istNow.getHours() < 23 ||
+      (istNow.getHours() === 23 && istNow.getMinutes() < 50)
+    ) {
+      ist1150PM = addDays(ist1150PM, -1);
+    }
+
+    const from: Date = new Date(ist1150PM.getTime() - IST_OFFSET_MS);
+    const to: Date = new Date(from.getTime() + 24 * 60 * 60 * 1000);
+
+    logger.info(
+      `Streak job processing date range: ${from.toISOString()} to ${to.toISOString()}`
+    );
+
     const userActivityController = new UserActivityController();
 
-    const mockReq = {} as any;
+    const mockReq = {
+      body: { from, to },
+    } as any;
     const mockRes = {
       status: (code: number) => mockRes,
       json: (data: any) => {
         logger.info(`Streak completed: ${data.message}`);
+        logger.info(
+          `Streaks incremented: ${data.data?.streaksIncremented}, Streaks reset: ${data.data?.streaksReset}`
+        );
       },
     } as any;
 

--- a/apps/backend/src/lib/dayRange.ts
+++ b/apps/backend/src/lib/dayRange.ts
@@ -1,16 +1,22 @@
-import { startOfDay, subDays } from "date-fns";
+import { addDays, setHours, setMinutes, setSeconds } from "date-fns";
 
 export function getDayWindow(): { from: Date; to: Date } {
   const IST_OFFSET_MS: number = 5.5 * 60 * 60 * 1000;
 
-  const nowUtc: Date = new Date();
-  const nowIst: Date = new Date(nowUtc.getTime() + IST_OFFSET_MS);
+  const now: Date = new Date();
+  const istNow: Date = new Date(now.getTime() + IST_OFFSET_MS);
 
-  const startOfTodayIst: Date = startOfDay(nowIst);
-  const startOfPrevDayIst: Date = subDays(startOfTodayIst, 1);
+  let ist1150PM: Date = setSeconds(setMinutes(setHours(istNow, 23), 50), 0);
 
-  const from: Date = new Date(startOfPrevDayIst.getTime() - IST_OFFSET_MS);
-  const to: Date = new Date(startOfTodayIst.getTime() - IST_OFFSET_MS);
+  if (
+    istNow.getHours() < 23 ||
+    (istNow.getHours() === 23 && istNow.getMinutes() < 50)
+  ) {
+    ist1150PM = addDays(ist1150PM, -1);
+  }
+
+  const from: Date = new Date(ist1150PM.getTime() - IST_OFFSET_MS);
+  const to: Date = new Date(from.getTime() + 24 * 60 * 60 * 1000);
 
   return { from, to };
 }


### PR DESCRIPTION
This pull request updates how the streak reset job calculates and handles the date range for user activity streaks, ensuring it aligns with the intended 11:50 PM IST cutoff. The changes improve consistency in date range calculations across the codebase and allow for more flexible testing and invocation of the streak reset logic.

**Date range calculation improvements:**

* Refactored `getDayWindow` in `dayRange.ts` to consistently calculate the date range based on a fixed 11:50 PM IST cutoff, using `date-fns` utilities for clarity and reliability.
* Updated the streak job in `streak.job.ts` to use the new date range logic, logging the exact range being processed and passing it explicitly to the controller.

**Controller flexibility:**

* Modified `resetStreak` in `userActivity.controller.ts` to accept an optional custom date range from the request body, falling back to the default window if not provided. This allows easier testing and more controlled invocations.

**Logging enhancements:**

* Added detailed logging in `streak.job.ts` to output the processed date range and streak statistics for better monitoring and debugging.… allow custom date input in reset streak method and improve logging in streak job