### PR TITLE
refactor(api): update cache control settings for articles API to enha…

### DIFF
--- a/apps/frontend/src/app/api/articles/[slug]/route.ts
+++ b/apps/frontend/src/app/api/articles/[slug]/route.ts
@@ -17,8 +17,9 @@ export async function GET(
       headers: {
         "Content-Type": "application/json",
         "Authorization": API_KEY,
+        "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
       },
-      next: { revalidate: 600 }, // Revalidate every 10 minutes for individual articles
+      cache: "no-store" as RequestCache,
     });
 
     if (!response.ok) {
@@ -42,7 +43,7 @@ export async function GET(
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, s-maxage=600, stale-while-revalidate=1200",
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
       },
     });
   } catch (error) {

--- a/apps/frontend/src/app/api/articles/route.ts
+++ b/apps/frontend/src/app/api/articles/route.ts
@@ -20,9 +20,9 @@ export async function GET(request: NextRequest) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": API_KEY,
+        "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
       },
-      // Add cache control for better performance
-      next: { revalidate: 300 }, // Revalidate every 5 minutes
+      cache: "no-store" as RequestCache,
     });
 
     if (!response.ok) {
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
       },
     });
   } catch (error) {


### PR DESCRIPTION
This pull request updates the caching strategy for the articles API endpoints to ensure fresher data and more consistent cache control. The main changes involve disabling server-side caching for upstream API requests and reducing the cache duration in API responses.

**Caching changes:**

* Disabled Next.js server-side caching for upstream API calls by replacing the `next: { revalidate: ... }` option with `cache: "no-store"` and adding strict `Cache-Control` headers to the request in both `[slug]/route.ts` and `route.ts`. ([apps/frontend/src/app/api/articles/[slug]/route.tsR20-R22](diffhunk://#diff-9a163ebb5d4594bf76c220bbbe77ee373f87b35ac61d25dbd239a590698cd88fR20-R22), [apps/frontend/src/app/api/articles/route.tsR23-R25](diffhunk://#diff-d9ff9d62b2735fb8676803406806d68667e97fd023c5337e77e0bf4db3c41566R23-R25))
* Reduced the cache duration in API responses by changing the `Cache-Control` header from 5–10 minutes to 60 seconds, and the `stale-while-revalidate` window from 10–20 minutes to 120 seconds, in both `[slug]/route.ts` and `route.ts`. ([apps/frontend/src/app/api/articles/[slug]/route.tsL45-R46](diffhunk://#diff-9a163ebb5d4594bf76c220bbbe77ee373f87b35ac61d25dbd239a590698cd88fL45-R46), [apps/frontend/src/app/api/articles/route.tsL49-R49](diffhunk://#diff-d9ff9d62b2735fb8676803406806d68667e97fd023c5337e77e0bf4db3c41566L49-R49))…nce performance and ensure fresh data retrieval