### PR TITLE
Dev/int

### DIFF
--- a/apps/frontend/src/components/AppDownloadBanner.tsx
+++ b/apps/frontend/src/components/AppDownloadBanner.tsx
@@ -51,7 +51,7 @@ export const AppDownloadBanner = ({ hasTabBar = false }: AppDownloadBannerProps)
   const bottomPosition = hasTabBar ? 'bottom-[64px]' : 'bottom-0'
 
   return (
-    <div className={`fixed ${bottomPosition} left-0 right-0 z-[100] bg-white border-t border-gray-200 shadow-[0_-4px_10px_-1px_rgba(0,0,0,0.1)] p-3 flex justify-between items-center sm:hidden animate-in slide-in-from-bottom-2`}>
+    <div className={`fixed ${bottomPosition} left-0 right-0 z-40 bg-white border-t border-gray-200 shadow-[0_-4px_10px_-1px_rgba(0,0,0,0.1)] p-3 flex justify-between items-center sm:hidden animate-in slide-in-from-bottom-2`}>
       <button onClick={handleDismiss} className="mr-3 text-gray-400 hover:text-gray-600 transition-colors p-1" aria-label="Close banner">
         <X size={18} />
       </button>

--- a/apps/frontend/src/components/AppDownloadBanner.tsx
+++ b/apps/frontend/src/components/AppDownloadBanner.tsx
@@ -41,7 +41,7 @@ export const AppDownloadBanner = ({ hasTabBar = false }: AppDownloadBannerProps)
       e.preventDefault()
       const fallbackUrl = "https://play.google.com/store/apps/details?id=com.rankmarg.app&hl=en_IN"
       if (/android/i.test(navigator.userAgent)) {
-        window.location.href = `intent://open#Intent;package=com.rankmarg.app;scheme=rankmarg;S.browser_fallback_url=${encodeURIComponent(fallbackUrl)};end`
+        window.location.href = `intent:#Intent;action=android.intent.action.MAIN;category=android.intent.category.LAUNCHER;launchFlags=0x10000000;package=com.rankmarg.app;S.browser_fallback_url=${encodeURIComponent(fallbackUrl)};end`
       } else {
         window.location.href = fallbackUrl
       }


### PR DESCRIPTION
This pull request makes two targeted improvements to the `AppDownloadBanner` component to enhance Android app launch behavior and adjust the banner's display layering.

Android intent URL update:

* Changed the Android intent URL in the click handler to use a more explicit intent format, specifying action, category, and launch flags for better compatibility and reliability when opening the app from the banner.

UI layering adjustment:

* Updated the banner's container `div` to use `z-40` instead of `z-[100]` for its z-index, ensuring more consistent stacking order with other UI elements.